### PR TITLE
Fix for case when granted FB permissions array not equal to requested…

### DIFF
--- a/GASocialLogin/Facebook/GAFacebookLoginService.swift
+++ b/GASocialLogin/Facebook/GAFacebookLoginService.swift
@@ -131,7 +131,7 @@ extension GASocialLogin
                     
                 case false:
                     print("FACEBOOK LOGIN: SUCCESS - PERMISSIONS: \(String(describing: result.grantedPermissions))")
-                    guard result.grantedPermissions.count == permissions.count else { completion(.missingPermissions); return }
+                    guard permissions.filter({ result.grantedPermissions.contains($0) }).count == permissions.count else { completion(.missingPermissions); return }
                     strongSelf.getUserInfo(byFields: fields, loginResult: result, completion: completion)
                 }
             }


### PR DESCRIPTION
example: 
requested `permissions = ["public_profile"]`
result `grantedPermissions = ["email", "public_profile"]`